### PR TITLE
Match `os_arch` insensitively

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -10,7 +10,7 @@
 get_download_urls() {
   curl -fL "https://api.github.com/repos/dhall-lang/dhall-haskell/releases/tags/$1" \
   | grep download_url                                                               \
-  | grep "$2"                                                                       \
+  | grep -i "$2"                                                                       \
   | cut -d: -f2-
 }
 


### PR DESCRIPTION
Since [dhall-haskell 1.41.2](https://github.com/dhall-lang/dhall-haskell/releases/tag/1.41.2), the asset names for macos have changed in terms of case (i.e. "macOS" as opposed to previously, "macos").